### PR TITLE
Issue #9 - Fixed broken homepage Breadcrumb

### DIFF
--- a/theme/layouts/_breadcrumbs.ejs
+++ b/theme/layouts/_breadcrumbs.ejs
@@ -1,10 +1,10 @@
 <%
 const query = site.queryPages;
-if (page.pathname !== '') {
+if (page.pathname !== "") {
   const [currentPage] = query(({pathname}) => page.pathname === pathname);
-  const pathnameParts = currentPage.originalPathname.split('/'); %>
+  const pathnameParts = currentPage.originalPathname.split("/"); %>
   
-  <nav aria-label='Breadcrumb' id='breadcrumb'>
+  <nav aria-label="Breadcrumb" id="breadcrumb">
   <ol>
     <% 
     for (let i=0; i < pathnameParts.length; i++) {
@@ -12,10 +12,10 @@ if (page.pathname !== '') {
       const [{pathname, title}] = query(({originalPathname}) => 
         originalPathname == pickOriginalPathname); %>
         <li>
-        <a href='<%= pathname %>'><%= title %></a>
+        <a href="/<%= pathname %>"><%= title %></a>
         </li>
     <% } %>
-    <li aria-current='page'><%= currentPage.title %></li>
+    <li aria-current="page"><%= currentPage.title %></li>
   </ol>
 </nav>
 <% } %>


### PR DESCRIPTION
Seems like we both missed that relative path for the breadcrumbs were used, current issue contains:
- Use absolute path for breadcrumbs
- Converted `'`s to `"` for consistency with other EJS files